### PR TITLE
Added support of query band to log session query band for queries executing from Airflow

### DIFF
--- a/airflow/providers/teradata/hooks/teradata.py
+++ b/airflow/providers/teradata/hooks/teradata.py
@@ -139,7 +139,7 @@ class TeradataHook(DbApiHook):
         """
         Create and return a Teradata Connection object using teradatasql client.
 
-        Establishes connection to a Teradata SQL databadse using config corresponding to teradata_conn_id.
+        Establishes connection to a Teradata SQL database using config corresponding to teradata_conn_id.
 
         :return: a Teradata connection object
         """

--- a/airflow/providers/teradata/hooks/teradata.py
+++ b/airflow/providers/teradata/hooks/teradata.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 import teradatasql

--- a/airflow/providers/teradata/hooks/teradata.py
+++ b/airflow/providers/teradata/hooks/teradata.py
@@ -47,7 +47,7 @@ def _map_param(value):
 
 
 def _handle_user_query_band_text(query_band_text) -> str:
-    """Validates given query_band and appending if required values missed in query_band"""
+    """Validate given query_band and append if required values missed in query_band."""
     # Ensures 'appname=airflow' and 'org=teradata-internal-telem' are in query_band_text.
     if query_band_text is not None:
         # Making sure appname in query_band contains 'airflow'
@@ -153,7 +153,7 @@ class TeradataHook(DbApiHook):
         return teradata_conn
 
     def set_query_band(self, query_band_text, teradata_conn):
-        """Setting SESSION Query Band for each connection session"""
+        """Set SESSION Query Band for each connection session."""
         try:
             query_band_text = _handle_user_query_band_text(query_band_text)
             set_query_band_sql = f"SET QUERY_BAND='{query_band_text}' FOR SESSION"

--- a/airflow/providers/teradata/hooks/teradata.py
+++ b/airflow/providers/teradata/hooks/teradata.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import sqlalchemy
 import teradatasql
@@ -47,38 +47,38 @@ def _map_param(value):
 
 
 def _handle_user_query_band_text(query_band_text) -> str:
-    """Validates given query_band and appending if required values missed in query_band """
+    """Validates given query_band and appending if required values missed in query_band"""
     # Ensures 'appname=airflow' and 'org=teradata-internal-telem' are in query_band_text.
     if query_band_text is not None:
         # Making sure appname in query_band contains 'airflow'
-        pattern = r'appname\s*=\s*([^;]*)'
+        pattern = r"appname\s*=\s*([^;]*)"
         # Search for the pattern in the query_band_text
         match = re.search(pattern, query_band_text)
         if match:
             appname_value = match.group(1).strip()
             # if appname exists and airflow not exists in appname then appending 'airflow' to existing
             # appname value
-            if 'airflow' not in appname_value.lower():
+            if "airflow" not in appname_value.lower():
                 new_appname_value = appname_value + "_airflow"
                 # Optionally, you can replace the original value in the query_band_text
-                updated_query_band_text = re.sub(pattern, f'appname={new_appname_value}', query_band_text)
+                updated_query_band_text = re.sub(pattern, f"appname={new_appname_value}", query_band_text)
                 query_band_text = updated_query_band_text
         else:
             # if appname doesn't exist in query_band, adding 'appname=airflow'
-            if len(query_band_text.strip()) > 0 and not query_band_text.endswith(';'):
-                query_band_text += ';'
-            query_band_text += 'appname=airflow;'
+            if len(query_band_text.strip()) > 0 and not query_band_text.endswith(";"):
+                query_band_text += ";"
+            query_band_text += "appname=airflow;"
 
         # checking org doesn't exist in query_band, appending 'org=teradata-internal-telem'
         #  If it exists, user might have set some value of their own, so doing nothing in that case
-        pattern = r'org\s*=\s*([^;]*)'
+        pattern = r"org\s*=\s*([^;]*)"
         match = re.search(pattern, query_band_text)
         if not match:
-            if not query_band_text.endswith(';'):
-                query_band_text += ';'
-            query_band_text += 'org=teradata-internal-telem;'
+            if not query_band_text.endswith(";"):
+                query_band_text += ";"
+            query_band_text += "org=teradata-internal-telem;"
     else:
-        query_band_text = 'appname=airflow;org=teradata-internal-telem;'
+        query_band_text = "appname=airflow;org=teradata-internal-telem;"
 
     return query_band_text
 
@@ -145,8 +145,8 @@ class TeradataHook(DbApiHook):
         """
         teradata_conn_config: dict = self._get_conn_config_teradatasql()
         query_band_text = None
-        if 'query_band' in teradata_conn_config:
-            query_band_text = teradata_conn_config.pop('query_band')
+        if "query_band" in teradata_conn_config:
+            query_band_text = teradata_conn_config.pop("query_band")
         teradata_conn = teradatasql.connect(**teradata_conn_config)
         # setting query band
         self.set_query_band(query_band_text, teradata_conn)
@@ -156,7 +156,7 @@ class TeradataHook(DbApiHook):
         """Setting SESSION Query Band for each connection session"""
         try:
             query_band_text = _handle_user_query_band_text(query_band_text)
-            set_query_band_sql = "SET QUERY_BAND='%s' FOR SESSION" % query_band_text
+            set_query_band_sql = f"SET QUERY_BAND='{query_band_text}' FOR SESSION"
             with teradata_conn.cursor() as cur:
                 cur.execute(set_query_band_sql)
         except Exception as ex:

--- a/docs/apache-airflow-providers-teradata/connections/teradata.rst
+++ b/docs/apache-airflow-providers-teradata/connections/teradata.rst
@@ -90,6 +90,7 @@ QueryBand can be specified using extra connection configuration parameter as bel
        {
           "query_band": "appname=airflow;org=test;"
        }
+
 When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify query_band as URL-encoded as below.
 
 For example:

--- a/docs/apache-airflow-providers-teradata/connections/teradata.rst
+++ b/docs/apache-airflow-providers-teradata/connections/teradata.rst
@@ -80,3 +80,20 @@ Extra (optional)
     .. code-block:: bash
 
         export AIRFLOW_CONN_TERADATA_DEFAULT='teradata://teradata_user:XXXXXXXXXXXX@1.1.1.1:/teradatadb?tmode=tera&sslmode=verify-ca&sslca=%2Ftmp%2Fserver-ca.pem'
+
+Setting QueryBand
+-----------------
+QueryBand can be specified using extra connection configuration parameter as below. The value specified in query_band will be set as session query band.
+
+    .. code-block:: json
+
+       {
+          "query_band": "appname=airflow;org=test;"
+       }
+When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify query_band as URL-encoded as below.
+
+For example:
+
+    .. code-block:: bash
+
+        export AIRFLOW_CONN_TERADATA_DEFAULT='teradata://teradata_user:XXXXXXXXXXXX@1.1.1.1:/teradatadb?query_band=appname%3Dairflow%3Borg%3Dtest%3B'

--- a/tests/providers/teradata/hooks/test_teradata.py
+++ b/tests/providers/teradata/hooks/test_teradata.py
@@ -26,6 +26,7 @@ import pytest
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.teradata.hooks.teradata import TeradataHook
+from airflow.providers.teradata.hooks.teradata import _handle_user_query_band_text
 
 
 class TestTeradataHook:
@@ -281,7 +282,7 @@ class TestTeradataHook:
         ):
             self.test_db_hook.bulk_insert_rows("table", rows)
 
-    def test_callproc_dict(self):
+    def test_call_proc_dict(self):
         parameters = {"a": 1, "b": 2, "c": 3}
 
         class bindvar(int):
@@ -312,9 +313,6 @@ class TestTeradataHook:
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert "query_band" not in kwargs
-
-
-from airflow.providers.teradata.hooks.teradata import _handle_user_query_band_text
 
 
 def test_handle_user_query_band_text_invalid():

--- a/tests/providers/teradata/hooks/test_teradata.py
+++ b/tests/providers/teradata/hooks/test_teradata.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from unittest import mock
-from unittest.mock import Mock, patch
 
 import pytest
 
@@ -319,35 +318,35 @@ from airflow.providers.teradata.hooks.teradata import _handle_user_query_band_te
 
 
 def test_handle_user_query_band_text_invalid():
-    query_band_text = _handle_user_query_band_text('invalid_queryband')
-    assert query_band_text == 'invalid_queryband;appname=airflow;org=teradata-internal-telem;'
+    query_band_text = _handle_user_query_band_text("invalid_queryband")
+    assert query_band_text == "invalid_queryband;appname=airflow;org=teradata-internal-telem;"
 
 
 def test_handle_user_query_band_text_override_appname():
-    query_band_text = _handle_user_query_band_text('appname=test;')
-    assert query_band_text == 'appname=test_airflow;org=teradata-internal-telem;'
+    query_band_text = _handle_user_query_band_text("appname=test;")
+    assert query_band_text == "appname=test_airflow;org=teradata-internal-telem;"
 
 
 def test_handle_user_query_band_text_append_org():
-    query_band_text = _handle_user_query_band_text('appname=airflow;')
-    assert query_band_text == 'appname=airflow;org=teradata-internal-telem;'
+    query_band_text = _handle_user_query_band_text("appname=airflow;")
+    assert query_band_text == "appname=airflow;org=teradata-internal-telem;"
 
 
 def test_handle_user_query_band_text_user_org():
-    query_band_text = _handle_user_query_band_text('appname=airflow;org=test')
-    assert query_band_text == 'appname=airflow;org=test'
+    query_band_text = _handle_user_query_band_text("appname=airflow;org=test")
+    assert query_band_text == "appname=airflow;org=test"
 
 
 def test_handle_user_query_band_text_none():
     query_band_text = _handle_user_query_band_text(None)
-    assert query_band_text == 'appname=airflow;org=teradata-internal-telem;'
+    assert query_band_text == "appname=airflow;org=teradata-internal-telem;"
 
 
 def test_handle_user_query_band_text_no_appname():
-    query_band_text = _handle_user_query_band_text('org=test;')
-    assert query_band_text == 'org=test;appname=airflow;'
+    query_band_text = _handle_user_query_band_text("org=test;")
+    assert query_band_text == "org=test;appname=airflow;"
 
 
 def test_handle_user_query_band_text_no_appname_with_teradata_org():
-    query_band_text = _handle_user_query_band_text('org=teradata-internal-telem;')
-    assert query_band_text == 'org=teradata-internal-telem;appname=airflow;'
+    query_band_text = _handle_user_query_band_text("org=teradata-internal-telem;")
+    assert query_band_text == "org=teradata-internal-telem;appname=airflow;"

--- a/tests/providers/teradata/hooks/test_teradata.py
+++ b/tests/providers/teradata/hooks/test_teradata.py
@@ -25,8 +25,7 @@ import pytest
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
-from airflow.providers.teradata.hooks.teradata import TeradataHook
-from airflow.providers.teradata.hooks.teradata import _handle_user_query_band_text
+from airflow.providers.teradata.hooks.teradata import TeradataHook, _handle_user_query_band_text
 
 
 class TestTeradataHook:

--- a/tests/providers/teradata/hooks/test_teradata.py
+++ b/tests/providers/teradata/hooks/test_teradata.py
@@ -316,7 +316,7 @@ class TestTeradataHook:
 
 def test_handle_user_query_band_text_invalid():
     query_band_text = _handle_user_query_band_text("invalid_queryband")
-    assert query_band_text == "invalid_queryband;appname=airflow;org=teradata-internal-telem;"
+    assert query_band_text == "invalid_queryband;org=teradata-internal-telem;appname=airflow;"
 
 
 def test_handle_user_query_band_text_override_appname():
@@ -336,7 +336,7 @@ def test_handle_user_query_band_text_user_org():
 
 def test_handle_user_query_band_text_none():
     query_band_text = _handle_user_query_band_text(None)
-    assert query_band_text == "appname=airflow;org=teradata-internal-telem;"
+    assert query_band_text == "org=teradata-internal-telem;appname=airflow;"
 
 
 def test_handle_user_query_band_text_no_appname():


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Added support of specifying user defined query band in Airflow Teradata connection UI. This providers provision to users to specify query band of their choice so that airflow teradata provider logs queries running from Airflow Teradata Provider with provider Query band text as session query band.

https://teradata-pe.atlassian.net/browse/IDE-24322?focusedCommentId=5206490


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
