### PR TITLE
Build correct SQLAlchemy URI in Teradata Hook

### DIFF
--- a/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
-import sqlalchemy
 import teradatasql
+from sqlalchemy.engine import URL
 from teradatasql import TeradataConnection
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     except ImportError:
         from airflow.models.connection import Connection  # type: ignore[assignment]
 
+DEFAULT_DB_PORT = 1025
 PARAM_TYPES = {bool, float, int, str}
 
 
@@ -166,7 +167,7 @@ class TeradataHook(DbApiHook):
         conn: Connection = self.get_connection(self.get_conn_id())
         conn_config = {
             "host": conn.host or "localhost",
-            "dbs_port": conn.port or "1025",
+            "dbs_port": conn.port or DEFAULT_DB_PORT,
             "database": conn.schema or "",
             "user": conn.login or "dbc",
             "password": conn.password or "dbc",
@@ -195,12 +196,32 @@ class TeradataHook(DbApiHook):
 
         return conn_config
 
-    def get_sqlalchemy_engine(self, engine_kwargs=None):
-        """Return a connection object using sqlalchemy."""
-        conn: Connection = self.get_connection(self.get_conn_id())
-        link = f"teradatasql://{conn.login}:{conn.password}@{conn.host}"
-        connection = sqlalchemy.create_engine(link)
-        return connection
+    @property
+    def sqlalchemy_url(self) -> URL:
+        """
+         Override to return a Sqlalchemy.engine.URL object from the Teradata connection.
+
+        :return: the extracted sqlalchemy.engine.URL object.
+        """
+        connection = self.get_connection(self.get_conn_id())
+        # Adding only teradatasqlalchemy supported connection parameters.
+        # https://pypi.org/project/teradatasqlalchemy/#ConnectionParameters
+        url_kwargs = {
+            "drivername": "teradatasql",
+            "username": connection.login,
+            "password": connection.password,
+            "host": connection.host,
+            "port": connection.port,
+        }
+
+        if connection.schema:  # Only include database if it's not None or empty
+            url_kwargs["database"] = connection.schema
+
+        return URL.create(**url_kwargs)
+
+    def get_uri(self) -> str:
+        """Override DbApiHook get_uri method for get_sqlalchemy_engine()."""
+        return self.sqlalchemy_url.render_as_string()
 
     @staticmethod
     def get_ui_field_behaviour() -> dict:

--- a/providers/teradata/tests/unit/teradata/hooks/test_teradata.py
+++ b/providers/teradata/tests/unit/teradata/hooks/test_teradata.py
@@ -40,6 +40,11 @@ class TestTeradataHook:
         self.db_hook.get_connection.return_value = self.connection
         self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
+        self.conn.login = "mock_login"
+        self.conn.password = "mock_password"
+        self.conn.host = "mock_host"
+        self.conn.schema = "mock_schema"
+        self.conn.port = 1025
         self.conn.cursor.return_value = self.cur
         self.conn.extra_dejson = {}
         conn = self.conn
@@ -53,6 +58,7 @@ class TestTeradataHook:
                 return conn
 
         self.test_db_hook = UnitTestTeradataHook(teradata_conn_id="teradata_conn_id")
+        self.test_db_hook.get_uri = mock.Mock(return_value="sqlite://")
 
     @mock.patch("teradatasql.connect")
     def test_get_conn(self, mock_connect):
@@ -62,7 +68,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
 
@@ -76,7 +82,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["tmode"] == "tera"
@@ -91,7 +97,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["sslmode"] == "require"
@@ -106,7 +112,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["sslmode"] == "verify-ca"
@@ -122,7 +128,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["sslmode"] == "verify-full"
@@ -138,7 +144,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["sslcrc"] == "sslcrc"
@@ -153,7 +159,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["sslprotocol"] == "protocol"
@@ -168,25 +174,25 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["sslcipher"] == "cipher"
 
-    @mock.patch("sqlalchemy.create_engine")
-    def test_get_sqlalchemy_conn(self, mock_connect):
-        self.db_hook.get_sqlalchemy_engine()
-        assert mock_connect.call_count == 1
-        args = mock_connect.call_args.args
-        assert len(args) == 1
-        expected_link = (
-            f"teradatasql://{self.connection.login}:{self.connection.password}@{self.connection.host}"
-        )
-        assert expected_link == args[0]
+    def test_get_uri_without_schema(self):
+        self.connection.schema = ""  # simulate missing schema
+        self.db_hook.get_connection.return_value = self.connection
+        uri = self.db_hook.get_uri()
+        expected_uri = f"teradatasql://{self.connection.login}:***@{self.connection.host}"
+        assert uri == expected_uri
 
     def test_get_uri(self):
         ret_uri = self.db_hook.get_uri()
-        expected_uri = f"teradata://{self.connection.login}:{self.connection.password}@{self.connection.host}/{self.connection.schema}"
+        expected_uri = (
+            f"teradatasql://{self.connection.login}:***@{self.connection.host}/{self.connection.schema}"
+            if self.connection.schema
+            else f"teradatasql://{self.connection.login}:***@{self.connection.host}"
+        )
         assert expected_uri == ret_uri
 
     def test_get_records(self):
@@ -260,7 +266,7 @@ class TestTeradataHook:
         assert args == ()
         assert kwargs["host"] == "host"
         assert kwargs["database"] == "schema"
-        assert kwargs["dbs_port"] == "1025"
+        assert kwargs["dbs_port"] == 1025
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert "query_band" not in kwargs


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
related: https://github.com/apache/airflow/issues/38195

Why
The default implementation of DbApiHook.get_uri does not conform to the standard Teradata connection format. 

How
Override sqlalchemy_url property to follow the official Teradata SQLAlchemy URI format documented here:
https://pypi.org/project/teradatasqlalchemy/#ConnectionParameters

Return the properly rendered SQLAlchemy URL in get_uri.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
